### PR TITLE
Hide Control.Lens.Empty

### DIFF
--- a/src/Data/Meep.hs
+++ b/src/Data/Meep.hs
@@ -33,7 +33,7 @@ module Data.Meep
   ) where
 
 import Control.Applicative (pure, liftA2)
-import Control.Lens
+import Control.Lens hiding (Empty)
 import Data.Bifoldable (Bifoldable(..))
 import Data.Bifunctor.Apply (Biapply(..))
 import Data.Bitraversable (Bitraversable(..))


### PR DESCRIPTION
Newer version of `lens` produces some ambiguity. Not sure though it's a best way to get rid of it
